### PR TITLE
fix: RoutableHandler to return handler's Enabled

### DIFF
--- a/router.go
+++ b/router.go
@@ -44,7 +44,7 @@ type RoutableHandler struct {
 
 // Implements slog.Handler
 func (h *RoutableHandler) Enabled(ctx context.Context, l slog.Level) bool {
-	return true
+	return h.handler.Enabled(ctx, l)
 }
 
 // Implements slog.Handler


### PR DESCRIPTION
It seems to make sense for the `RoutableHandler`'s `Enabled` method to return its handlers `Enabled` method instead of `true`.

It also fixes a bug when if a router's matcher matches the log level, the minimum log level set through `&slog.HandlerOptions{}` ends up being ignored (example below).

```go
levelFilter := func(levels ...slog.Level) func(ctx context.Context, r slog.Record) bool {
    return func(ctx context.Context, r slog.Record) bool {
        return slices.Contains(levels, r.Level)
    }
}

logger := slog.New(
    slogmulti.Router().
        Add(
            slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}),
            levelFilter(slog.LevelWarn, slog.LevelError)).
        Add(
            slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}),
            levelFilter(slog.LevelDebug, slog.LevelInfo)). // before the fix, debug level logs were also sent to stdout
        Handler(),
)
```