### PR TITLE
feat: use standard errors library join instead of hashicorp multierror

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,11 @@ module github.com/samber/slog-multi
 go 1.21
 
 require (
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/samber/lo v1.38.1
 	go.uber.org/goleak v1.2.1
 )
 
 require (
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/stretchr/testify v1.8.2 // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=

--- a/multi.go
+++ b/multi.go
@@ -2,9 +2,9 @@ package slogmulti
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/samber/lo"
 )
 
@@ -40,9 +40,7 @@ func (h *FanoutHandler) Handle(ctx context.Context, r slog.Record) error {
 			err := try(func() error {
 				return h.handlers[i].Handle(ctx, r.Clone())
 			})
-			if err != nil {
-				result = multierror.Append(result, err)
-			}
+			result = errors.Join(result, err)
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #7

It’s arguably best to use the standard library when possible.
Also the [licensing](https://github.com/hashicorp/go-multierror?tab=MPL-2.0-1-ov-file#readme) of https://github.com/hashicorp/go-multierror is a bit annoying, e.g. see «3.2. Distribution of Executable Form».

Thanks!