### PR TITLE
fix: clone attributes for each handler

### DIFF
--- a/multi.go
+++ b/multi.go
@@ -3,6 +3,7 @@ package slogmulti
 import (
 	"context"
 	"log/slog"
+	"slices"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/samber/lo"
@@ -52,7 +53,7 @@ func (h *FanoutHandler) Handle(ctx context.Context, r slog.Record) error {
 // Implements slog.Handler
 func (h *FanoutHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	handers := lo.Map(h.handlers, func(h slog.Handler, _ int) slog.Handler {
-		return h.WithAttrs(attrs)
+		return h.WithAttrs(slices.Clone(attrs))
 	})
 	return Fanout(handers...)
 }


### PR DESCRIPTION
Hey!

The [docs](https://pkg.go.dev/log/slog#Handler.WithAttrs) say this for `slog.Handler.WithAttrs`:
> The Handler owns the slice: it may retain, modify or discard it.

Therefore, it seems best to clone it for each handler in a multi-handler.